### PR TITLE
Fix Node Constraint Checking

### DIFF
--- a/main.js
+++ b/main.js
@@ -412,7 +412,9 @@
                     }
                     break;
                 case Constraint.Node:
-                    checkNode(player.dest.x, player.dest.y);
+                    const dstx = (player.dest.x + level.width) % level.width;
+                    const dsty = (player.dest.y + level.height) % level.height;
+                    checkNode(dstx, dsty);
                     break;
                 default:
                     console.warn('No constraint selected');


### PR DESCRIPTION
Node-constraint currently has an issue when wrapping around the board. For example, the sequence "ULRL" in Level 2 is considered legal even though location `(6, 9)` is visited twice.

This is allowed because `checkNode` is called without applying the modulus operator before checking, leading the game to check square `(-4, 9)` after the fourth move in the example above.

This PR fixed that by applying the modulus analogously as it is done in the Edge-constraint checking code.